### PR TITLE
update image build version to 0.6.5

### DIFF
--- a/deployments/dev-net/scripts/setup.sh
+++ b/deployments/dev-net/scripts/setup.sh
@@ -4,7 +4,7 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
 
-export RELEASE=0.6.4
+export RELEASE=0.6.5
 export IMAGE_TAG=2.1.0
 export CONFIG=./config
 export VOLUME=./volume


### PR DESCRIPTION
Update the RELEASE value inside deployments/dev-net/scripts/setup.sh to 0.6.5. This is the version number being used when run the dn-build script to build the docker images