### PR TITLE
fix: run 2org integration test during create-release

### DIFF
--- a/deployments/dev-net/compose.2org.gwtest.yaml
+++ b/deployments/dev-net/compose.2org.gwtest.yaml
@@ -6,13 +6,12 @@ networks:
 services:
   tester:
     environment:
-      - TEST_TARGETS=ref-impl
-      - TEST_OPTIONS=gw-org1 4001 gw-org2 4001
+      - TEST_OPTIONS=ref-impl
+      - TEST_TARGETS=gw-org1 4001 gw-org2 4001
       - LOG_LEVEL=$LOG_LEVEL
       - LOG_TARGET=$LOG_TARGET
     image: $TEST_IMAGE
     container_name: tester
-    working_dir: /home/app/packages/tester
+    working_dir: /home/app
     networks:
       - openplatform
-  # command: ["jest", "integration.test"]

--- a/deployments/dev-net/dn-test.gw-2.sh
+++ b/deployments/dev-net/dn-test.gw-2.sh
@@ -47,8 +47,6 @@ TEST_EXIT_CODE=`docker wait tester`;
 
 docker logs tester
 
-./cleanup.sh
-
 if [ -z ${TEST_EXIT_CODE+x} ] || [ "$TEST_EXIT_CODE" -ne 0 ] ; then
   printf "${RED}Tests Failed${NC} - Exit Code: $TEST_EXIT_CODE\n"
   docker logs gw-org1
@@ -58,6 +56,9 @@ if [ -z ${TEST_EXIT_CODE+x} ] || [ "$TEST_EXIT_CODE" -ne 0 ] ; then
 else
   printf "${GREEN}Tests Passed${NC}\n"
 fi
+
+# if test fails, it won't run cleanup
+./cleanup.sh
 
 duration=$SECONDS
 printf "${GREEN}$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed.\n\n${NC}"

--- a/deployments/dev-net/scripts/setup.sh
+++ b/deployments/dev-net/scripts/setup.sh
@@ -136,7 +136,7 @@ getConfig() {
 # $3 - optional: expected
 containerWait() {
   FOUND=false
-  COUNT=90
+  COUNT=120
   while [[ ("$FOUND"=false) && (COUNT -gt 0) ]]; do
     if [ $# -eq 3 ]; then
       RESULT=`docker container exec -i $1 "$2" | grep -e "$3"`
@@ -187,4 +187,3 @@ parseArgs() {
     esac
   fi
 }
-

--- a/packages/tester/Dockerfile
+++ b/packages/tester/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache curl \
   && cp /usr/share/zoneinfo/Asia/Hong_Kong /etc/localtime \
   && echo "Asia/Hong_Kong" > /etc/timezone \
   && cd /home/app \
-  && npm install --production \
+  && npm install \
   && npm install -g jest \
   && apk del .build-deps
 

--- a/packages/tester/entrypoint.sh
+++ b/packages/tester/entrypoint.sh
@@ -33,7 +33,7 @@ case $1 in
     HOSTS=
     DELIM=
     STATE=0
-    for VAL in $1; do
+    for VAL in $2; do
       HOSTS=$HOSTS$DELIM$VAL
       if [ $STATE -eq 0 ]; then
         DELIM=":"
@@ -84,11 +84,11 @@ case $1 in
       exec jest intg.3org.test
     else
       echo "Starting 2 orgs integration test..."
-      exec jest intg.2org.test
+      exec jest --verbose intg.2org.test
     fi
     ;;
-
   *)
-    echo "Uknown test target $1"
+    echo "Unknown test options $1"
+    exit 1
     ;;
 esac

--- a/packages/tester/src/__tests__/intg.2org.test.ts
+++ b/packages/tester/src/__tests__/intg.2org.test.ts
@@ -54,15 +54,15 @@ beforeAll(async () => {
       method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({
         username: user1, email: user1, password
       })})
-    .then(res => res.json())
-    .then(data => {
-      if (data.username && data.id) {
-        return { reg1: true, rol1: data.id };
-      } else {
-        console.log(`Register Org1 user: ${JSON.stringify(data)}`);
-        return { reg1: false, rol1: null };
-      }
-    });
+      .then(res => res.json())
+      .then(data => {
+        if (data.username && data.id) {
+          return { reg1: true, rol1: data.id };
+        } else {
+          console.log(`Register Org1 user: ${JSON.stringify(data)}`);
+          return { reg1: false, rol1: null };
+        }
+      });
     if (!reg1) {
       console.log(`♨️♨️  Registering to OAUTH server ${AUTH_REG_1} failed`);
       return;
@@ -72,15 +72,15 @@ beforeAll(async () => {
       method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({
         username: user1, password
       })})
-    .then(res => res.json())
-    .then(data => {
-      if (data.id === rol1) {
-        return { log1: true, tok1: data.access_token };
-      } else {
-        console.log(`Login Org1 user: ${JSON.stringify(data)}`);
-        return { log1: false, tok1: null };
-      }
-    });
+      .then(res => res.json())
+      .then(data => {
+        if (data.id === rol1) {
+          return { log1: true, tok1: data.access_token };
+        } else {
+          console.log(`Login Org1 user: ${JSON.stringify(data)}`);
+          return { log1: false, tok1: null };
+        }
+      });
     if (!log1) {
       console.log(`♨️♨️  Logging in to OAUTH server ${AUTH_LOG_1} as ${user1} / ${password} failed`);
       return;
@@ -90,8 +90,8 @@ beforeAll(async () => {
       method: 'POST', headers: { 'content-type': 'application/json', authorization: `bearer ${tok1}` }, body: JSON.stringify({
         operationName: 'CreateWallet', query: CREATE_WALLET
       })})
-    .then(res => res.json())
-    .then(({ data }) => data);
+      .then(res => res.json())
+      .then(({ data }) => data);
     if (!org1Ready) {
       console.log(`♨️♨️  Create wallet for user ${rol1} in gateway ${GATEWAY1} failed`);
       return;
@@ -104,15 +104,15 @@ beforeAll(async () => {
       method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({
         username: user2, email: user2, password
       })})
-    .then(res => res.json())
-    .then(data => {
-      if (data.username && data.id) {
-        return { reg2: true, rol2: data.id };
-      } else {
-        console.log(`Register Org2 user: ${JSON.stringify(data)}`);
-        return { reg2: false, rol2: null };
-      }
-    });
+      .then(res => res.json())
+      .then(data => {
+        if (data.username && data.id) {
+          return { reg2: true, rol2: data.id };
+        } else {
+          console.log(`Register Org2 user: ${JSON.stringify(data)}`);
+          return { reg2: false, rol2: null };
+        }
+      });
     if (!reg2) {
       console.log(`♨️♨️  Registering to OAUTH server ${AUTH_REG_2} failed`);
       return;
@@ -122,15 +122,15 @@ beforeAll(async () => {
       method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({
         username: user2, password
       })})
-    .then(res => res.json())
-    .then(data => {
-      if (data.id === rol2) {
-        return { log2: true, tok2: data.access_token };
-      } else {
-        console.log(`Login Org2 user: ${JSON.stringify(data)}`);
-        return { log2: false, tok2: null };
-      }
-    });
+      .then(res => res.json())
+      .then(data => {
+        if (data.id === rol2) {
+          return { log2: true, tok2: data.access_token };
+        } else {
+          console.log(`Login Org2 user: ${JSON.stringify(data)}`);
+          return { log2: false, tok2: null };
+        }
+      });
     if (!log2) {
       console.log(`♨️♨️  Logging in to OAUTH server ${AUTH_LOG_2} as ${user2} / ${password} failed`);
       return;
@@ -140,8 +140,8 @@ beforeAll(async () => {
       method: 'POST', headers: { 'content-type': 'application/json', authorization: `bearer ${tok2}` }, body: JSON.stringify({
         operationName: 'CreateWallet', query: CREATE_WALLET
       })})
-    .then(res => res.json())
-    .then(({ data }) => data);
+      .then(res => res.json())
+      .then(({ data }) => data);
     if (!org2Ready) {
       console.log(`♨️♨️  Create wallet for user ${rol2} in gateway ${GATEWAY2} failed`);
       return;
@@ -151,6 +151,8 @@ beforeAll(async () => {
     isReady = org1Ready && org2Ready;
   } catch (e) {
     console.error(e);
+    const sleep10 = new Promise((resolve) => setTimeout(() => resolve(true), 10000));
+    await sleep10;
     process.exit(1);
   }
 });
@@ -499,11 +501,11 @@ describe('Multi-Org Test - Query Loans', () => {
         method: 'POST', headers: { 'content-type': 'application/json', authorization: `bearer ${accessToken1}` }, body: JSON.stringify({
           operationName: 'GetLoanById', query: GET_LOAN_BY_ID_ORG1, variables: { loanId: loanId1 }
         })})
-      .then(res => res.json())
-      .then(({ data }) => expect(data.getLoanById).toMatchSnapshot({
-        comment: expect.any(String)
-      }))
-      .catch(_ => expect(false).toBeTruthy());
+        .then(res => res.json())
+        .then(({ data }) => expect(data.getLoanById).toMatchSnapshot({
+          comment: expect.any(String)
+        }))
+        .catch(_ => expect(false).toBeTruthy());
       return;
     }
     expect(false).toBeTruthy();
@@ -543,11 +545,11 @@ describe('Multi-Org Test - Query Loans', () => {
         method: 'POST', headers: { 'content-type': 'application/json', authorization: `bearer ${accessToken2}` }, body: JSON.stringify({
           operationName: 'GetLoanById', query: GET_LOAN_BY_ID_ORG2, variables: { loanId: loanId2 }
         })})
-      .then(res => res.json())
-      .then(({ data }) => expect(data.getLoanById).toMatchSnapshot({
-        comment: expect.any(String)
-      }))
-      .catch(_ => expect(false).toBeTruthy());
+        .then(res => res.json())
+        .then(({ data }) => expect(data.getLoanById).toMatchSnapshot({
+          comment: expect.any(String)
+        }))
+        .catch(_ => expect(false).toBeTruthy());
       return;
     }
     expect(false).toBeTruthy();
@@ -587,14 +589,14 @@ describe('Multi-Org Test - Query Loans', () => {
         method: 'POST', headers: { 'content-type': 'application/json', authorization: `bearer ${accessToken2}` }, body: JSON.stringify({
           operationName: 'GetDocumentById', query: GET_DOCUMENT_BY_ID, variables: { documentId: docId1a }
         })})
-      .then(res => res.json())
-      .then(({ data }) => expect(data.getDocumentById).toMatchSnapshot({
-        documentId: expect.any(String), loanId: expect.any(String), timestamp: expect.any(String),
-        loan: {
-          loanId: expect.any(String), timestamp: expect.any(String),
-        }
-      }))
-      .catch(_ => expect(false).toBeTruthy());
+        .then(res => res.json())
+        .then(({ data }) => expect(data.getDocumentById).toMatchSnapshot({
+          documentId: expect.any(String), loanId: expect.any(String), timestamp: expect.any(String),
+          loan: {
+            loanId: expect.any(String), timestamp: expect.any(String),
+          }
+        }))
+        .catch(_ => expect(false).toBeTruthy());
       return;
     }
     expect(false).toBeTruthy();
@@ -606,14 +608,14 @@ describe('Multi-Org Test - Query Loans', () => {
         method: 'POST', headers: { 'content-type': 'application/json', authorization: `bearer ${accessToken1}` }, body: JSON.stringify({
           operationName: 'GetDocumentById', query: GET_DOCUMENT_BY_ID, variables: { documentId: docId2b }
         })})
-      .then(res => res.json())
-      .then(({ data }) => expect(data.getDocumentById).toMatchSnapshot({
-        documentId: expect.any(String), loanId: expect.any(String), timestamp: expect.any(String),
-        loan: {
-          loanId: expect.any(String), timestamp: expect.any(String),
-        }
-      }))
-      .catch(_ => expect(false).toBeTruthy());
+        .then(res => res.json())
+        .then(({ data }) => expect(data.getDocumentById).toMatchSnapshot({
+          documentId: expect.any(String), loanId: expect.any(String), timestamp: expect.any(String),
+          loan: {
+            loanId: expect.any(String), timestamp: expect.any(String),
+          }
+        }))
+        .catch(_ => expect(false).toBeTruthy());
       return;
     }
     expect(false).toBeTruthy();
@@ -681,9 +683,9 @@ describe('Multi-Org Test - Query Loans', () => {
         method: 'POST', headers: { 'content-type': 'application/json', authorization: `bearer ${accessToken2}` }, body: JSON.stringify({
           operationName: 'GetCommitsByLoanId', query: GET_COMMITS_BY_LOAN, variables: { loanId: loanId1 }
         })})
-      .then(res => res.json())
-      .then(({ data }) => expect(data.getCommitsByLoanId).toMatchSnapshot())
-      .catch(_ => expect(false).toBeTruthy());
+        .then(res => res.json())
+        .then(({ data }) => expect(data.getCommitsByLoanId).toMatchSnapshot())
+        .catch(_ => expect(false).toBeTruthy());
       return;
     }
     expect(false).toBeTruthy();
@@ -695,9 +697,9 @@ describe('Multi-Org Test - Query Loans', () => {
         method: 'POST', headers: { 'content-type': 'application/json', authorization: `bearer ${accessToken1}` }, body: JSON.stringify({
           operationName: 'GetCommitsByDocument', query: GET_COMMITS_BY_DOCUMENT, variables: { documentId: docId2a }
         })})
-      .then(res => res.json())
-      .then(({ data }) => expect(data.getCommitsByDocumentId).toMatchSnapshot())
-      .catch(_ => expect(false).toBeTruthy());
+        .then(res => res.json())
+        .then(({ data }) => expect(data.getCommitsByDocumentId).toMatchSnapshot())
+        .catch(_ => expect(false).toBeTruthy());
       return;
     }
     expect(false).toBeTruthy();


### PR DESCRIPTION
Previously, the 2org integration test was incorrectly skipped, and got PASS during create-release. 

The bug came from double faults:
1. compose.2org.gwtest.yaml
```
# CORRECT
      - TEST_OPTIONS=ref-impl 
      - TEST_TARGETS=gw-org1 4001 gw-org2 4001
# WRONG
      - TEST_TARGETS=ref-impl 
      - TEST_OPTIONS =gw-org1 4001 gw-org2 4001
```

2. entrypoint.sh
```
# CORRECT
  *)
    echo "Unknown test options $1"
    exit 1
    ;;
# WRONG
  *)
    echo "Unknown test options $1"
    ;;
```

**NOTE:**   
I did not check other integration tests. While current CI is 2org gw test. Need to revisit other tests have similar situations. 