### PR TITLE
fix: issue215 - incorrect sorting

### DIFF
--- a/packages/fabric-cqrs/package.json
+++ b/packages/fabric-cqrs/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@fabric-es/operator": "^0.7.12",
+    "debug": "^4.3.2",
     "did-jwt": "^5.0.2",
     "dotenv": "^8.1.0",
     "fabric-contract-api": "2.2.1",
@@ -60,6 +61,7 @@
     "winston": "^3.2.1"
   },
   "devDependencies": {
+    "@types/debug": "^4.1.7",
     "@types/ioredis": "^4.16.4",
     "@types/jest": "^26.0.20",
     "@types/js-yaml": "^3.12.4",

--- a/packages/fabric-cqrs/src/queryHandler/__tests__/__snapshots__/qdb.unit-test.ts.snap
+++ b/packages/fabric-cqrs/src/queryHandler/__tests__/__snapshots__/qdb.unit-test.ts.snap
@@ -1,21 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Projecion db test should fullTextSearchEntity by "de" 1`] = `
+exports[`Projecion db test should fullTextSearchEntity by "de" sort-by DESC 1`] = `
 Object {
   "data": Array [
     Object {
-      "createdAt": "1590738792",
+      "createdAt": "1590740003",
       "creator": "org1-admin",
-      "description": "query handler #2 proj",
+      "description": "query handler #7 proj",
       "eventInvolved": Array [
         "Increment",
         "Increment",
       ],
-      "id": "qh_proj_test_001",
-      "modifiedAt": "1590739000",
+      "id": "qh_proj_test_003",
+      "modifiedAt": "1590740004",
       "organization": Array [
         "Org1MSP",
       ],
+      "privateData": undefined,
       "tags": Array [
         "projection",
       ],
@@ -35,6 +36,74 @@ Object {
       "organization": Array [
         "Org1MSP",
       ],
+      "privateData": undefined,
+      "tags": Array [
+        "projection",
+      ],
+      "value": 3,
+    },
+    Object {
+      "createdAt": "1590738792",
+      "creator": "org1-admin",
+      "description": "query handler #2 proj",
+      "eventInvolved": Array [
+        "Increment",
+        "Increment",
+      ],
+      "id": "qh_proj_test_001",
+      "modifiedAt": "1590739000",
+      "organization": Array [
+        "Org1MSP",
+      ],
+      "privateData": undefined,
+      "tags": Array [
+        "projection",
+      ],
+      "value": 2,
+    },
+  ],
+  "message": "3 record(s) returned",
+  "status": "OK",
+}
+`;
+
+exports[`Projecion db test should fullTextSearchEntity by "de", sort-by ASC 1`] = `
+Object {
+  "data": Array [
+    Object {
+      "createdAt": "1590738792",
+      "creator": "org1-admin",
+      "description": "query handler #2 proj",
+      "eventInvolved": Array [
+        "Increment",
+        "Increment",
+      ],
+      "id": "qh_proj_test_001",
+      "modifiedAt": "1590739000",
+      "organization": Array [
+        "Org1MSP",
+      ],
+      "privateData": undefined,
+      "tags": Array [
+        "projection",
+      ],
+      "value": 2,
+    },
+    Object {
+      "createdAt": "1590740000",
+      "creator": "org1-admin",
+      "description": "query handler #5 proj",
+      "eventInvolved": Array [
+        "Increment",
+        "Increment",
+        "Increment",
+      ],
+      "id": "qh_proj_test_002",
+      "modifiedAt": "1590740002",
+      "organization": Array [
+        "Org1MSP",
+      ],
+      "privateData": undefined,
       "tags": Array [
         "projection",
       ],
@@ -53,6 +122,7 @@ Object {
       "organization": Array [
         "Org1MSP",
       ],
+      "privateData": undefined,
       "tags": Array [
         "projection",
       ],

--- a/packages/fabric-cqrs/src/queryHandler/__tests__/qdb.unit-test.ts
+++ b/packages/fabric-cqrs/src/queryHandler/__tests__/qdb.unit-test.ts
@@ -20,7 +20,7 @@ import type { QueryDatabase, RedisRepository, OutputCommit } from '../types';
 import { commit, commits, faultReducer, newCommit } from './__utils__';
 
 /**
- * running it: .dn-run.0-db-red.sh
+ * ./dn-run.sh 1 auth
  */
 let queryDatabase: QueryDatabase;
 let client: Redisearch;
@@ -38,12 +38,11 @@ beforeAll(async () => {
   await client.connect();
 
   Counter.entityName = ENTITYNAME;
-  counter = createRedisRepository<Counter, CounterInRedis, OutputCounter>(
-    Counter, {
-      client,
-      fields,
-      postSelector,
-      preSelector,
+  counter = createRedisRepository<Counter, CounterInRedis, OutputCounter>(Counter, {
+    client,
+    fields,
+    postSelector,
+    preSelector,
   });
 
   queryDatabase = createQueryDatabase(client, { [ENTITYNAME]: counter });
@@ -224,12 +223,21 @@ describe('Projecion db test', () => {
         expect(errors[0].message).toContain('not loaded nor in schema');
       }));
 
-  it('should fullTextSearchEntity by "de"', async () =>
+  it('should fullTextSearchEntity by "de", sort-by ASC', async () =>
     queryDatabase
       .fullTextSearchEntity({
         query: 'handler',
         entityName: ENTITYNAME,
         param: { sortBy: { sort: 'ASC', field: 'de' } },
+      })
+      .then((result) => expect(result).toMatchSnapshot()));
+
+  it('should fullTextSearchEntity by "de" sort-by DESC', async () =>
+    queryDatabase
+      .fullTextSearchEntity({
+        query: 'handler',
+        entityName: ENTITYNAME,
+        param: { sortBy: { sort: 'DESC', field: 'de' } },
       })
       .then((result) => expect(result).toMatchSnapshot()));
 

--- a/packages/fabric-cqrs/src/queryHandler/__tests__/reconcile.unit-test.ts
+++ b/packages/fabric-cqrs/src/queryHandler/__tests__/reconcile.unit-test.ts
@@ -42,7 +42,7 @@ let counterRedisRepo: RedisRepository<OutputCounter>;
 let commitRepo: RedisRepository<OutputCommit>;
 
 /**
- * ./dn-run.1-db-red-auth.sh
+ * ./dn-run.sh 1 auth
  */
 beforeAll(async () => {
   rimraf.sync(`${walletPath}/${orgAdminId}.id`);

--- a/packages/fabric-cqrs/src/queryHandler/__tests__/subscribe.unit-test.ts
+++ b/packages/fabric-cqrs/src/queryHandler/__tests__/subscribe.unit-test.ts
@@ -652,9 +652,9 @@ describe('Pagination tests for getPaginatedEntityById', () => {
         expect(data.hasMore).toBeFalsy();
         expect(data.cursor).toEqual(3);
         expect(data.items.map(({ id }) => id)).toEqual([
+          'qh_sub_test_001',
           'qh_pag_test_002',
           'qh_pag_test_004',
-          'qh_sub_test_001',
         ]);
       }));
 

--- a/packages/fabric-cqrs/src/queryHandler/pipelineExec.ts
+++ b/packages/fabric-cqrs/src/queryHandler/pipelineExec.ts
@@ -20,8 +20,8 @@ export const pipelineExec: <TResult = any>(
 
   ({
     DELETE: () => _keys.forEach((key) => pipeline.del(key)),
-    HGETALL: () => _keys.sort().forEach((key) => pipeline.hgetall(key)),
-    GET: () => _keys.sort().forEach((key) => pipeline.get(key)),
+    HGETALL: () => _keys.forEach((key) => pipeline.hgetall(key)),
+    GET: () => _keys.forEach((key) => pipeline.get(key)),
   }[action]());
 
   return pipeline.exec();

--- a/packages/fabric-cqrs/src/store/query/__tests__/query.store.unit-test.ts
+++ b/packages/fabric-cqrs/src/store/query/__tests__/query.store.unit-test.ts
@@ -188,7 +188,6 @@ describe('Store/query: failure tests', () => {
         ErrorAction: QUERY_ERROR,
         logger,
       },
-      (result) => Object.values<Commit>(result).reverse()
     )({ entityName, id: null }).then(({ data, status, error }) => {
       expect(data).toBeNull();
       expect(status).toEqual('ERROR');
@@ -336,7 +335,6 @@ describe('Store/query Test', () => {
         ErrorAction: QUERY_ERROR,
         logger,
       },
-      (result) => (result ? Object.values<OutputCommit>(result).reverse() : null)
     )({ entityName, id }).then(({ data, status }) => {
       // in previous step, "mergeCommit", the raw Commit appends a derived fields,
       // creator, event, and ts, resulting OutputCommit
@@ -383,7 +381,9 @@ describe('Store/query Test', () => {
       expect(currentStates[0].id).toEqual(id);
     }));
 
-  it('should #2 queryByEntityId: DESC order', async () =>
+  // TODO: REVISIT HERE if it should be sorted in QueryDatabase, by "queryCommitsByPattern" in createRedisRepository
+  // Currently, is hardcoded "ASC"
+  it('should #2 queryByEntityId', async () =>
     dispatcher<OutputCommit[], { entityName: string; id: string }>(
       (payload) => queryByEntityId(payload),
       {
@@ -393,8 +393,7 @@ describe('Store/query Test', () => {
         SuccessAction: QUERY_SUCCESS,
         ErrorAction: QUERY_ERROR,
         logger,
-      },
-      (result) => (result ? Object.values<OutputCommit>(result).reverse() : null)
+      }
     )({ entityName, id }).then(({ data, status }) => {
       const mockedOutputCommit2 = Object.assign({}, newCommit, {
         creator: '',
@@ -408,7 +407,7 @@ describe('Store/query Test', () => {
         ts: 1590738792,
         signedRequest: '',
       });
-      expect(data).toEqual([mockedOutputCommit2, mockedOutputCommit1]);
+      expect(data).toEqual([mockedOutputCommit1, mockedOutputCommit2]);
       expect(status).toEqual('OK');
     }));
 
@@ -481,7 +480,7 @@ describe('Store/query Test', () => {
       ]);
     }));
 
-  it('should #3 queryByEntityId: DESC order', async () =>
+  it('should #3 queryByEntityId: ASC order (hard coded)', async () =>
     dispatcher<Commit[], { entityName: string; id: string }>(
       (payload) => queryByEntityId(payload),
       {
@@ -491,10 +490,9 @@ describe('Store/query Test', () => {
         SuccessAction: QUERY_SUCCESS,
         ErrorAction: QUERY_ERROR,
         logger,
-      },
-      (result) => (result ? Object.values<Commit>(result).reverse() : null)
+      }
     )({ entityName, id: 'test_002' }).then(({ data, status }) => {
-      expect(data[0]).toEqual({
+      expect(data[2]).toEqual({
         id: 'test_002',
         entityName: 'store_query',
         version: 2,
@@ -574,7 +572,7 @@ describe('Store/query Test', () => {
       ]);
     }));
 
-  it('should #4 queryByEntityId: DESC order', async () =>
+  it('should #4 queryByEntityId', async () =>
     dispatcher<OutputCommit[], { entityName: string; id: string }>(
       (payload) => queryByEntityId(payload),
       {
@@ -585,7 +583,6 @@ describe('Store/query Test', () => {
         ErrorAction: QUERY_ERROR,
         logger,
       },
-      (result) => (result ? Object.values<OutputCommit>(result).reverse() : null)
     )({ entityName, id: 'test_003' }).then(({ data, status }) => {
       expect(data).toEqual([]);
       expect(status).toEqual('OK');

--- a/packages/fabric-cqrs/src/types/commit.ts
+++ b/packages/fabric-cqrs/src/types/commit.ts
@@ -106,15 +106,15 @@ export type Commit = {
   /** organization Id **/
   mspId?: string;
 
-  /** events array **/
+  /** RESERVED FIELD: events array **/
   events?: BaseEvent[];
 
-  /** hash of privatedata's events string **/
+  /** RESERVED FIELD: hash of privatedata's events string **/
   hash?: string;
 
-  /** stringified events **/
+  /** RESERVED FIELD: stringified events **/
   eventsString?: string;
 
-  /** signed request **/
+  /** RESERVED FIELD: signed request **/
   signedRequest?: string;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2641,6 +2641,13 @@
   dependencies:
     "@types/express" "*"
 
+"@types/debug@^4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
+  integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/elliptic@^6.4.12":
   version "6.4.12"
   resolved "https://registry.yarnpkg.com/@types/elliptic/-/elliptic-6.4.12.tgz#e8add831f9cc9a88d9d84b3733ff669b68eaa124"
@@ -2868,6 +2875,11 @@
   integrity sha512-edtGMEdit146JwwIeyQeHHg9yID4WSolQPxpEorHmN3KuytuCHyn2ELNr5Uxy8SerniFbbkmgKMrGM933am5BQ==
   dependencies:
     "@types/node" "*"
+
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/node-fetch@2.5.4":
   version "2.5.4"
@@ -5161,6 +5173,13 @@ debug@^3.0, debug@^3.1.0, debug@^3.2.6:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
The commit retrieval is hardcoded to ASC, by design; because all commits retrieved from Redis is supposed to internal call. 

The entity retrieval is fixed; using FTParam, i.e. Full text search input param. 